### PR TITLE
Fix: Making changes in .nyc configuration to include utils directory

### DIFF
--- a/.nycrc.json
+++ b/.nycrc.json
@@ -6,11 +6,10 @@
     "coverage/**",
     "src/config/database.ts",
     "test/**",
-    "src/helpers/swagger.ts",
+    "src/utils/swagger.ts",
     "index.ts",
     "src/database",
-    "src/docs",
-    "src/utils"
+    "src/docs"
   ],
   "cache": false,
   "all": true,


### PR DESCRIPTION
#### What does this PR do?
Edited the .nyc file to change some configuration about files to exlude

#### Description of Task to be completed?

- Removed `src/utils` directory from .nyc ignore file
- Corrected `"src/helpers/swagger.ts",` to `"src/utils/swagger.ts",`

Before:
![image](https://github.com/atlp-rwanda/e-commerce-bitcrafters-bn/assets/39400022/d4be49f6-c68a-4ea7-8159-8119e3c3bfe2)

After:
![image](https://github.com/atlp-rwanda/e-commerce-bitcrafters-bn/assets/39400022/dc530847-b4d4-47fb-9400-f12e191fd77d)

