### PR TITLE
Fix: add return statements configurations  into code climate file

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,4 +1,5 @@
 version: '2'
+
 checks:
   complex-logic:
     enabled: false
@@ -9,6 +10,10 @@ checks:
       threshold: 70
     eslint:
       enabled: true
+  return-statements:
+    enabled: true
+    config:
+      threshold: 50
   similar-code:
     config:
       threshold: 75


### PR DESCRIPTION
 **What does this PR do?**
This PR adds configuration for the return-statements check in the codeclimate.yml file
 **Description of Task to be completed?**
We're enabling a check that makes sure our code doesn't have too many return statements in methods. This helps keep our code clean and easy to understand.

The fix involves enabling the return-statements check and setting a **threshold of 50 in the codeclimate.yml** file.


