### PR TITLE
Fix(View Collections): Added viewing collections

### DIFF
--- a/src/docs/collectionDocs.ts
+++ b/src/docs/collectionDocs.ts
@@ -1,6 +1,6 @@
 /**
  * @swagger
- * /collections/collection:
+ * /collections:
  *   post:
  *     summary: Create a new collection
  *     description: Create a new collection with the provided name

--- a/src/docs/productDocs.ts
+++ b/src/docs/productDocs.ts
@@ -128,6 +128,63 @@
 
 /**
  * @swagger
+ * /collections:
+ *   get:
+ *     summary: Get All Sellers Collection
+ *     description: Get collections created by a seller
+ *     tags:
+ *       [COLLECTION]
+ *     parameters:
+ *       - in: query
+ *         name: page
+ *         required: false
+ *         schema:
+ *           type: string
+ *         description: The page
+ *       - in: query
+ *         name: limit
+ *         required: false
+ *         schema:
+ *           type: string
+ *         description: The limit of Collections
+ *     responses:
+ *       '200':
+ *         description: Collections retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Collections retrieved successfully
+ *       '400':
+ *         description: Bad Request
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Seller has no collection
+ *       '401':
+ *         description: Unauthorized
+ *       '404':
+ *         description: Collection not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Collection not found
+ *       '500':
+ *         description: Internal server error
+ */
+/**
+ * @swagger
  * /collections/products:
  *   get:
  *     summary: Get Products

--- a/src/routes/productRoute.ts
+++ b/src/routes/productRoute.ts
@@ -25,12 +25,20 @@ router.post(
   productController.addProduct,
 )
 router.post(
-  '/collection',
+  '/',
   isAuthenticated,
   checkPermission(UserRole.SELLER),
   validateRequest(collectionSchema, 'body'),
   productController.createCollection,
 )
+
+router.get(
+  '/',
+  isAuthenticated,
+  checkPermission(UserRole.SELLER),
+  productController.listAllCollections,
+)
+
 router.patch(
   '/product/:productId/status',
   isAuthenticated,

--- a/src/services/productServices.ts
+++ b/src/services/productServices.ts
@@ -43,3 +43,9 @@ export const getProductCollectionCount = async (collectionId: string) => {
   })
   return products.length
 }
+export const getCollectionCount = async (sellerId:number) => {
+  const collections = await Collection.findAll({
+    where: { sellerId }
+  })
+  return collections.length
+}


### PR DESCRIPTION
#### What does this PR do?
The fix introduces the functionality of a seller being able to view the own collections

#### Description of Task to be completed?

#### How should this be manually tested?

- Navigate to swagger
- visit GET on endpoint `/collections`

#### Any background context you want to provide?
Make sure you are logged in as a seller

#### What are the relevant pivotal tracker/Trello stories?
No stories
#### Screenshots (if appropriate)
![Screenshot 2024-05-27 092848](https://github.com/atlp-rwanda/e-commerce-bitcrafters-bn/assets/39400022/3bd95dba-bd48-4756-a892-07efbed8b324)
![Screenshot 2024-05-27 092910](https://github.com/atlp-rwanda/e-commerce-bitcrafters-bn/assets/39400022/ad70b5eb-c989-4f7c-b550-580e96233555)


#### Questions:
