### PR TITLE
[#187364749] - Feature(Clear cart): User can clear their cart

### DIFF
--- a/src/controllers/cartController.ts
+++ b/src/controllers/cartController.ts
@@ -1,6 +1,7 @@
 import { Request, Response } from 'express'
 import Product from '../database/models/productModel'
 import Cart, { CartItem } from '../database/models/cartModel'
+import { clearCart } from '../services/cartService'
 
 /**
  * Cart Controller class
@@ -133,4 +134,36 @@ export default class cartController {
         .json({ message: 'Internal server error', error: error.message })
     }
   }
+ 
+  /**
+ * Clears the active cart for the user
+ * @param {Request} req - Express request object
+ * @param {Response} res - Express response object
+ * @returns {Promise<Response>} Promise that resolves to an Express response
+ */
+  static async clearCart(req: Request, res: Response): Promise<Response> {
+    try{
+        const userId = req.user?.id;
+  
+        if (!userId) {
+          return res.status(400).json({ message: 'User ID is required' });
+        }
+      
+        const cart = await Cart.findOne({
+          where: { buyerId: userId, status: 'active' },
+        });
+      
+        if (!cart) {
+          return res.status(404).json({ message: 'Cart not found' });
+        }
+    
+       await clearCart(cart.id)
+      
+        return res.status(200).json({ message: 'Cart cleared successfully' });
+    }
+    catch(error){
+        return res.status(500).json({ message: 'Internal server error', error:error.message });
+    } 
+  }
 }
+

--- a/src/docs/cartDocs.ts
+++ b/src/docs/cartDocs.ts
@@ -216,3 +216,65 @@
  *                   type: string
  *                   example: Internal server error
  */
+
+
+/**
+ * @swagger
+ * /cart/clear:
+ *   delete:
+ *     summary: Clear user cart
+ *     description: Clears the cart of a user
+ *     tags:
+ *       - CART
+ *     responses:
+ *       '201':
+ *         description: Cart cleared successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Cart cleared successfully
+ *       '400':
+ *         description: Bad Request
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Invalid quantity
+ *       '401':
+ *         description: Unauthorized
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Unauthorized
+ *       '404':
+ *         description: Product not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Product not found
+ *       '500':
+ *         description: Internal server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Internal server error
+ */

--- a/src/routes/cartRoute.ts
+++ b/src/routes/cartRoute.ts
@@ -23,4 +23,11 @@ router.get(
     cartController.viewCart,
   )
   
+
+router.delete(
+  '/clear',
+  isAuthenticated,
+  checkPermission(UserRole.BUYER),
+  cartController.clearCart,
+)
 export default router

--- a/src/services/cartService.ts
+++ b/src/services/cartService.ts
@@ -1,0 +1,25 @@
+
+import express from 'express'
+import { UUID } from 'crypto'
+import User from '../database/models/userModel'
+import Cart from '../database/models/cartModel'
+
+
+
+export const getCart = (cartId: UUID, userId:number) =>
+    Cart.findOne({ where: { id:cartId, status:"active", buyerId:userId } })
+
+export const createNewcart = async (userId:number)=>{
+    const cart = await Cart.create({
+        buyerId: userId,
+        items: [],
+        totalPrice: 0,
+        totalQuantity: 0,
+        status: 'active',
+      })
+
+      return cart
+}
+
+ 
+export const clearCart = (cartId: UUID|string) => Cart.update({items:[], totalPrice:0, totalQuantity:0}, {where:{ id:cartId}})

--- a/test/addToCart.test.ts
+++ b/test/addToCart.test.ts
@@ -357,3 +357,86 @@ describe('viewCart new', () => {
     })
   })
 })
+
+describe("clearCart new", () => {
+  let req: Request;
+  let res: Response;
+  let next: NextFunction;
+  let sandbox: sinon.SinonSandbox;
+  let findCartStub: sinon.SinonStub;
+  let updateCartStub: sinon.SinonStub;
+  let saveCartStub: sinon.SinonStub;
+  let mockUser: any;
+
+  beforeEach(() => {
+    req = {
+      headers: {},
+      query: {},
+    } as Request;
+    res = {
+      status: sinon.stub().returnsThis(),
+      json: sinon.stub(),
+      locals: {},
+    } as unknown as Response;
+    next = sinon.spy();
+    sandbox = sinon.createSandbox();
+    findCartStub = sinon.stub(Cart, 'findOne');
+    updateCartStub = sinon.stub(Cart, 'update');
+    // saveCartStub = sinon.stub(Cart, 'save');
+    mockUser = { userRole: 'buyer', id: 1 };
+    req.user = mockUser;
+  });
+
+  afterEach(() => {
+    sinon.restore();
+    sandbox.restore();
+  });
+
+  it("Should return 400 if user ID is missing", async () => {
+    delete req.user; 
+    await cartController.clearCart(req, res);
+
+    expect(res.status).to.be.calledOnceWith(400);
+    expect(res.json).to.be.calledWith({ message: "User ID is required" });
+  });
+
+  it("Should return 404 if cart not found", async () => {
+    findCartStub.resolves(null);
+    await cartController.clearCart(req, res);
+
+    expect(res.status).to.be.calledOnceWith(404);
+    expect(res.json).to.be.calledWith({ message: "Cart not found" });
+  });
+
+  it("Should return 500 on database error", async () => {
+    findCartStub.throws(new Error("Database error"));
+    await cartController.clearCart(req, res);
+
+    expect(res.status).to.be.calledOnceWith(500);
+    expect(res.json).to.be.calledWith({ message: "Internal server error", error: "Database error" });
+  });
+
+ 
+  it("Should clear empty cart successfully", async () => {
+    const mockedCart = { buyerId: 1, status: "active", items: [], totalPrice: 0, totalQuantity: 0 } as Cart;
+    findCartStub.resolves(mockedCart);
+    updateCartStub.resolves()
+
+    await cartController.clearCart(req, res);
+
+    expect(res.status).to.be.calledOnceWith(200);
+    expect(res.json).to.be.calledWith({ message: "Cart cleared successfully" });
+  });
+  it("Should clear cart and return success message", async () => {
+    const mockedCart = { buyerId: 1, status: "active", items: [], totalPrice: 0, totalQuantity: 0 } as Cart;
+    findCartStub.resolves(mockedCart);
+    const updatedCart = { buyerId: 1, status: "completed", items: [], totalPrice: 0, totalQuantity: 0 } as Cart;
+  
+    updateCartStub.resolves(updatedCart)
+    await cartController.clearCart(req, res);
+  
+    expect(res.status).to.be.calledOnceWith(200);
+    expect(res.json).to.be.calledWith({ message: "Cart cleared successfully" });
+    expect(updateCartStub.calledOnce).to.be.true;
+  });
+});

--- a/test/cartServices.test.ts
+++ b/test/cartServices.test.ts
@@ -1,0 +1,72 @@
+import chai, { expect } from 'chai'
+import sinon from 'sinon'
+import sinonChai from 'sinon-chai'
+import Cart from '../src/database/models/cartModel'
+import { getCart, createNewcart, clearCart } from '../src/services/cartService'
+import {
+  deleteProductById,
+  getProductById,
+} from '../src/services/productServices'
+
+chai.use(sinonChai)
+
+describe('Cart Services', () => {
+  let sandbox: sinon.SinonSandbox
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox()
+  })
+
+  afterEach(() => {
+    sandbox.restore()
+  })
+
+  describe('getCart', () => {
+    it('should return cart ', async () => {
+        const mockedCart = {
+            id: 'd95193b1-5548-4650-adea-71f622667095',
+            buyerId:1,
+            totalPrice:0,
+            totalQuantity:0,
+            items:[]
+          } as Cart
+      const findOneStub = sandbox.stub(Cart, 'findOne').resolves(mockedCart)
+
+      const result = await getCart('d95193b1-5548-4650-adea-71f622667095',1)
+
+      expect(findOneStub).to.have.been.called
+      expect(result).to.deep.equal(mockedCart)
+    })
+  })
+
+  describe('clearCart', () => {
+    it('should update Cart', async () => {
+      const updateStub = sandbox.stub(Cart, 'update').resolves()
+
+      await clearCart('d95193b1-5548-4650-adea-71f622667095',
+      )
+
+      expect(updateStub).to.have.been.called
+    })
+  })
+
+  describe('createNewCart', () => {
+    it('should create new Cart', async () => {
+        const mockedCart = {
+            id: 'd95193b1-5548-4650-adea-71f622667095',
+            buyerId:1,
+            totalPrice:0,
+            totalQuantity:0,
+            items:[]
+          } as Cart
+      const createStub = sandbox.stub(Cart, 'create').resolves(mockedCart)
+
+      const result = await createNewcart(1,
+      )
+
+      expect(createStub).to.have.been.called
+      expect(result).to.equal(mockedCart)
+
+    })
+  })
+})


### PR DESCRIPTION
**What does this PR do?**

 Clearing of the buyer's cart, including emptying the cart in the buyer's session and resetting the cart total to zero.

**Description of Task to be completed?**

1. Empty the buyer's cart.
2. Reset the cart total to zero.
3. Return a cart cleared confirmation message to the frontend.

#### How should this be manually tested?
On swagger documentation
1. Login and add your token appropriately
2. Navigate to `cart/clear` to clear the cart, the next time a new cart will be initiated

#### Any background context you want to provide?
A user has to be logged in and they should be a buyer

#### Loom Video Link
https://www.loom.com/share/045a148c2dc24d148bc05fb9c6ee6fb1?sid=f47f0b56-b926-46cc-b1ca-5cb619c8bc64

#### What are the relevant pivotal tracker/Trello stories?
[Delivers #187364749]