### PR TITLE
[#187364754] A user should be able to mark one/all Notification as read

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@types/sinon": "^17.0.3",
         "@types/sinon-chai": "^3.2.12",
         "@types/socket.io": "^3.0.2",
+        "@types/winston": "^2.4.4",
         "bcrypt": "^5.1.1",
         "bcryptjs": "^2.4.3",
         "body-parser": "^1.20.2",
@@ -1736,6 +1737,15 @@
       "version": "13.11.9",
       "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.11.9.tgz",
       "integrity": "sha512-FCTsikRozryfayPuiI46QzH3fnrOoctTjvOYZkho9BTFLCOZ2rgZJHMOVgCOfttjPJcgOx52EpkY0CMfy87MIw=="
+    },
+    "node_modules/@types/winston": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.4.4.tgz",
+      "integrity": "sha512-BVGCztsypW8EYwJ+Hq+QNYiT/MUyCif0ouBH+flrY66O5W+KIXAMML6E/0fJpm7VjIzgangahl5S03bJJQGrZw==",
+      "deprecated": "This is a stub types definition. winston provides its own type definitions, so you do not need this installed.",
+      "dependencies": {
+        "winston": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.8.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@types/sinon": "^17.0.3",
     "@types/sinon-chai": "^3.2.12",
     "@types/socket.io": "^3.0.2",
+    "@types/winston": "^2.4.4",
     "bcrypt": "^5.1.1",
     "bcryptjs": "^2.4.3",
     "body-parser": "^1.20.2",

--- a/src/controllers/NotificationController.ts
+++ b/src/controllers/NotificationController.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from 'express'
-import Notification from '../database/models/notificationModel'
+import Notification,{NotificationAttributes} from '../database/models/notificationModel'
 /**
  * Controller class for managing notifications-related operations ..
  */
@@ -26,6 +26,108 @@ class NotificationController {
       return res.status(500).json({ message: 'Internal server error' })
     }
   }
+  
+  /**
+   * Get a single notification by ID and mark it as read.
+   * @param {AuthenticatedRequest} req - Express request object
+   * @param {Response} res - Express response object
+   * @returns {Promise<Response>} Promise that resolves to an Express response
+   */
+  static async getSingleNotification(
+    req: Request,
+    res: Response,
+  ): Promise<Response> {
+    try {
+      const { notificationId } = req.params;
+      const userId = req.user.id;
+
+      const notification = await Notification.findOne({
+        where: { id: notificationId, userId },
+      });
+
+      if (!notification) {
+        return res.status(404).json({ message: 'Notification not found' });
+      }
+
+      if (!notification.isRead) {
+        await notification.update({ isRead: true });
+      }
+
+      return res.status(200).json({ data: notification });
+    } catch (error) {
+
+      return res.status(500).json({ message: 'Internal server error', error: error.message });
+    }
+  }
+
+/**
+ * Mark a notification as read or unread
+ * @param {Request} req - Express request object
+ * @param {Response} res - Express response object
+ * @returns {Promise<Response>} Promise that resolves to an Express response
+ */
+static async changeNotificationStatus(
+  req: Request,
+  res: Response,
+): Promise<Response> {
+  try {
+    const { notificationId } = req.params;
+
+    const notification = await Notification.findOne({
+      where: { id: notificationId },
+    });
+
+    if (!notification) {
+      return res.status(404).json({ message: 'Notification not found' });
+    }
+
+    const notificationStatus = !notification.isRead;
+    await notification.update({ isRead: notificationStatus });
+
+    const statusMessage = notificationStatus ? 'Notification is now read' : 'Notification is now unread';
+    return res.status(200).json({ message: statusMessage });
+  } catch (error) {
+    return res
+      .status(500)
+      .json({ message: 'Internal Server Error', error: error.message });
+  }
+}
+
+
+  /**
+ * Mark all notifications as read or unread
+ * @param {Request} req - Express request object
+ * @param {Response} res - Express response object
+ * @returns {Promise<Response>} Promise that resolves to an Express response
+ */
+static async changeAllNotificationStatus(
+  req: Request,
+  res: Response
+): Promise<Response> {
+  try {
+    const userId = req.user.id;
+    const notifications = await Notification.findAll({
+      where: { userId: userId },
+    });
+
+    if (notifications.length === 0) {
+      return res.status(404).json({ message: 'No notifications found' });
+    }
+
+
+    const allRead = notifications.every(notification => notification.isRead);
+    const newIsReadStatus = !allRead;
+
+    await Promise.all(notifications.map(notification => notification.update({ isRead: newIsReadStatus })));
+
+    const statusMessage = newIsReadStatus ? 'All notifications are now read' : 'All notifications are now unread';
+    return res.status(200).json({ message: statusMessage });
+  } catch (error) {
+    return res
+      .status(500)
+      .json({ message: 'Internal Server Error', error: error.message });
+  }
+}
 }
 
 export default NotificationController

--- a/src/database/models/notificationModel.ts
+++ b/src/database/models/notificationModel.ts
@@ -5,7 +5,7 @@ import sequelizeConnection from '../config/db.config'
 /**
  * NotificationAttributes Interface
  */
-interface NotificationAttributes {
+export interface NotificationAttributes {
   id: string
   userId: number
   productId: string

--- a/src/docs/notificationDocs.ts
+++ b/src/docs/notificationDocs.ts
@@ -57,3 +57,46 @@
  *                   type: string
  *                   description: Error message
  */
+
+/**
+ * @swagger
+ * /notifications/{notificationId}:
+ *   get:
+ *     summary: Get a single notification
+ *     tags: [Notifications]
+ *     parameters:
+ *       - in: path
+ *         name: notificationId
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *         required: true
+ *         description: The ID of the notification
+ *     responses:
+ *       200:
+ *         description: A single notification
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Notification'
+ *       404:
+ *         description: Notification not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   description: Error message
+ *       500:
+ *         description: Internal server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   description: Error message
+ */

--- a/src/docs/updateNotificationStatus.ts
+++ b/src/docs/updateNotificationStatus.ts
@@ -1,0 +1,80 @@
+/**
+ * @swagger
+ * components:
+ *   schemas:
+ *     notificationStatus:
+ *       type: object
+ *       properties:
+ *         isRead:
+ *           type: boolean
+ *           example: false
+ */
+/**
+ * @swagger
+ * /notifications/all:
+ *   put:
+ *     summary: Mark all notifications as read or unread
+ *     tags: [Notifications]
+ *     responses:
+ *       '200':
+ *         description: Status of all notifications updated
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "All notifications have been updated."
+ *       '500':
+ *         description: Internal Server Error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "Internal server error."
+ *                 error:
+ *                   type: string
+ *                   example: "Detailed error message."
+ */
+/**
+ * @swagger
+ * /notifications/{notificationId}/one:
+ *   put:
+ *     summary: Mark a notification as read or unread
+ *     tags: [Notifications]
+ *     parameters:
+ *       - in: path
+ *         name: notificationId
+ *         required: true
+ *         schema:
+ *           type: string
+ *         description: The ID of the notification
+ *     responses:
+ *       '200':
+ *         description: Status of the notification updated
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "Notification status has been updated."
+ *       '500':
+ *         description: Internal Server Error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: "Internal server error."
+ *                 error:
+ *                   type: string
+ *                   example: "Detailed error message."
+ */

--- a/src/routes/notificationRoute.ts
+++ b/src/routes/notificationRoute.ts
@@ -1,8 +1,24 @@
 import { Router } from 'express'
 import notificationController from '../controllers/NotificationController'
 import isAuthenticated from '../middlewares/authenticationMiddleware'
+import { authenticate } from 'passport'
 
 const router = Router()
 router.get('/', isAuthenticated, notificationController.getNotifications)
 
+router.get(
+  '/:notificationId',isAuthenticated,
+  notificationController.getSingleNotification
+)
+
+router.put(
+    '/:notificationId/one',
+    isAuthenticated,
+    notificationController.changeNotificationStatus,
+  )
+  router.put(
+    '/all',
+    isAuthenticated,
+    notificationController.changeAllNotificationStatus,
+  )
 export default router

--- a/test/notificationStatus.test.ts
+++ b/test/notificationStatus.test.ts
@@ -1,0 +1,216 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { Request, Response } from 'express';
+import NotificationController from '../src/controllers/NotificationController';
+import Notification from '../src/database/models/notificationModel';
+
+describe('NotificationController.changeNotificationStatus', () => {
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  let findOneStub: sinon.SinonStub;
+  let updateStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    req = {
+      params: { notificationId: '1' }
+    };
+
+    res = {
+      status: sinon.stub().returnsThis(),
+      json: sinon.stub().returnsThis(),
+    };
+
+    findOneStub = sinon.stub(Notification, 'findOne');
+    updateStub = sinon.stub();
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should return 404 if the notification is not found', async () => {
+    findOneStub.resolves(null);
+
+    await NotificationController.changeNotificationStatus(req as Request, res as Response);
+
+    expect(res.status).to.have.been.calledWith(404);
+    expect(res.json).to.have.been.calledWith({ message: 'Notification not found' });
+  });
+
+  it('should return 200 if the notification is now marked as read', async () => {
+    const notification = { isRead: false, update: updateStub.resolves() };
+    findOneStub.resolves(notification);
+
+    await NotificationController.changeNotificationStatus(req as Request, res as Response);
+
+    expect(notification.update).to.have.been.calledWith({ isRead: true });
+    expect(res.status).to.have.been.calledWith(200);
+    expect(res.json).to.have.been.calledWith({ message: 'Notification is now read' });
+  });
+
+  it('should return 200 if the notification is now marked as unread', async () => {
+    const notification = { isRead: true, update: updateStub.resolves() };
+    findOneStub.resolves(notification);
+
+    await NotificationController.changeNotificationStatus(req as Request, res as Response);
+
+    expect(notification.update).to.have.been.calledWith({ isRead: false });
+    expect(res.status).to.have.been.calledWith(200);
+    expect(res.json).to.have.been.calledWith({ message: 'Notification is now unread' });
+  });
+
+  it('should return 500 if there is a server error', async () => {
+    findOneStub.rejects(new Error('Database error'));
+
+    await NotificationController.changeNotificationStatus(req as Request, res as Response);
+
+    expect(res.status).to.have.been.calledWith(500);
+    expect(res.json).to.have.been.calledWith({
+      message: 'Internal Server Error',
+      error: 'Database error',
+    });
+  });
+});
+
+describe('NotificationController.getSingleNotification', () => {
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  let findOneStub: sinon.SinonStub;
+  let updateStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    req = {
+      params: { notificationId: '1' },
+      user: { id: 1 }
+    };
+
+    res = {
+      json: sinon.stub(),
+      status: sinon.stub().returnsThis()
+    };
+
+    findOneStub = sinon.stub(Notification, 'findOne');
+    updateStub = sinon.stub(Notification.prototype, 'update');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should return 404 if notification is not found', async () => {
+    findOneStub.resolves(null);
+
+    await NotificationController.getSingleNotification(req as Request, res as Response);
+
+    expect(res.status).to.have.been.calledWith(404);
+    expect(res.json).to.have.been.calledWith({ message: 'Notification not found' });
+  });
+
+  it('should return 200 and the notification if found and mark it as read if unread', async () => {
+    const notification = { id: '1', userId: '1', isRead: false, update: updateStub.resolves() };
+    findOneStub.resolves(notification);
+
+    await NotificationController.getSingleNotification(req as Request, res as Response);
+
+    expect(res.status).to.have.been.calledWith(200);
+    expect(res.json).to.have.been.calledWith({ data: notification });
+    expect(updateStub).to.have.been.calledWith({ isRead: true });
+  });
+
+  it('should return 200 and the notification if found and already read', async () => {
+    const notification = { id: '1', userId: '1', isRead: true, update: updateStub.resolves() };
+    findOneStub.resolves(notification);
+
+    await NotificationController.getSingleNotification(req as Request, res as Response);
+
+    expect(res.status).to.have.been.calledWith(200);
+    expect(res.json).to.have.been.calledWith({ data: notification });
+    expect(updateStub).to.not.have.been.called;
+  });
+
+  it('should return 500 on internal server error', async () => {
+    findOneStub.rejects(new Error('Database error'));
+
+    await NotificationController.getSingleNotification(req as Request, res as Response);
+
+    expect(res.status).to.have.been.calledWith(500);
+    expect(res.json).to.have.been.calledWith({
+      message: 'Internal server error',
+      error: 'Database error'
+    });
+  });
+});
+
+describe('NotificationController.changeAllNotificationStatus', () => {
+  let req: Partial<Request>;
+  let res: Partial<Response>;
+  let findAllStub: sinon.SinonStub;
+  let updateStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    req = {
+      user: { id: 1 }
+    };
+
+    res = {
+      status: sinon.stub().returnsThis(),
+      json: sinon.stub().returnsThis(),
+    };
+
+    findAllStub = sinon.stub(Notification, 'findAll');
+    updateStub = sinon.stub(Notification.prototype, 'update');
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('should return 404 if no notifications are found', async () => {
+    findAllStub.resolves([]);
+
+    await NotificationController.changeAllNotificationStatus(req as Request, res as Response);
+
+    expect(res.status).to.have.been.calledWith(404);
+    expect(res.json).to.have.been.calledWith({ message: 'No notifications found' });
+  });
+
+  it('should return 200 if all notifications are now marked as read', async () => {
+    const notifications = [
+      { isRead: false, update: updateStub.resolves() },
+      { isRead: false, update: updateStub.resolves() },
+    ];
+    findAllStub.resolves(notifications);
+
+    await NotificationController.changeAllNotificationStatus(req as Request, res as Response);
+
+    expect(updateStub).to.have.been.calledTwice;
+    expect(res.status).to.have.been.calledWith(200);
+    expect(res.json).to.have.been.calledWith({ message: 'All notifications are now read' });
+  });
+
+  it('should return 200 if all notifications are now marked as unread', async () => {
+    const notifications = [
+      { isRead: true, update: updateStub.resolves() },
+      { isRead: true, update: updateStub.resolves() },
+    ];
+    findAllStub.resolves(notifications);
+
+    await NotificationController.changeAllNotificationStatus(req as Request, res as Response);
+
+    expect(updateStub).to.have.been.calledTwice;
+    expect(res.status).to.have.been.calledWith(200);
+    expect(res.json).to.have.been.calledWith({ message: 'All notifications are now unread' });
+  });
+
+  it('should return 500 if there is a server error', async () => {
+    findAllStub.rejects(new Error('Database error'));
+
+    await NotificationController.changeAllNotificationStatus(req as Request, res as Response);
+
+    expect(res.status).to.have.been.calledWith(500);
+    expect(res.json).to.have.been.calledWith({
+      message: 'Internal Server Error',
+      error: 'Database error',
+    });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
This PR marks the notifications (all/one) either as read or unread
#### How should this be manually tested?
1. Authenticate as any user
2. Go to notifications/{notificationsId}/one for changing status of one notification
3. go to notifications/all for changing status of all notifications of that user
#### What are the relevant pivotal tracker/Trello stories?
Delivers[#187364754]
#### Screenshots (if appropriate)
https://www.loom.com/share/a42c052ac6024582947de0a9639e2f0f?sid=f8e499ed-e20a-4233-8169-09a48c0194cc
